### PR TITLE
Update convertion from hass value to ua_variant

### DIFF
--- a/custom_components/asyncua/__init__.py
+++ b/custom_components/asyncua/__init__.py
@@ -235,11 +235,9 @@ class OpcuaHub:
         """Get node variant type automatically and set the value."""
         node = self.client.get_node(nodeid=nodeid)
         node_type = await node.read_data_type_as_variant_type()
-        var = ua.Variant(
-            ua_utils.string_to_val(
-                string=str(value),
-                vtype=node_type,
-            )
+        var = ua_utils.string_to_variant(
+            string=str(value),
+            vtype=node_type,
         )
         await node.write_value(DataValue(var))
         return True


### PR DESCRIPTION
Use ua_utils.string_to_variant instead of ua_utils.string_to_val to have correct ua-datatype.

Fix B&R OPC-UA server which require correct datatype when updating values on server.
This fix will guarantee that the OPC-UA variant is initialized with the correct datatype.