### PR TITLE
Update asyncua requirement version to 1.2b1

### DIFF
--- a/custom_components/asyncua/manifest.json
+++ b/custom_components/asyncua/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "helper",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/KVSoong/asyncua/issues",
-  "requirements": ["asyncua==1.0.2"],
+  "requirements": ["asyncua==1.2b1"],
   "ssdp": [],
   "version": "v0.1.2",
   "zeroconf": []


### PR DESCRIPTION
Home Assistant 2026.03.1 moved to Python 3.14.
AsyncUA started with Version 1.2b1 to support this Python Version.